### PR TITLE
fix: enter discord successful status code correctly

### DIFF
--- a/notification/discord.py
+++ b/notification/discord.py
@@ -35,7 +35,7 @@ def notify_via_discord(notices):
     payload = build_discord_message(notices)
 
     response = requests.post(url, headers=headers, data=json.dumps(payload))
-    if response.status_code == 200:
+    if response.status_code == 204:
         logger.info("디스코드에 성공적으로 메시지를 전송하였습니다.")
     else:
         logger.error(f"{response.status_code} {response.text} 에러 발생")


### PR DESCRIPTION
슬랙 api와 달리 디스코드 api는 성공 시 204를 반환합니다. 따라서 이에 맞게 고쳐주었습니다.